### PR TITLE
Inform user if their media is invalid

### DIFF
--- a/xboxdash/main.c
+++ b/xboxdash/main.c
@@ -31,6 +31,15 @@ int main(void)
                 debugPrint("Launching...\n");
                 XLaunchXBE("\\Device\\CdRom0\\default.xbe");
             }
+            else
+            {
+                while (oldstate != state)
+                {
+                    debugPrint("Please double check if you've packed your ISO correctly.\n");
+                    debugPrint("REDUMP isos do not work in Xemu at the moment.\nPlease avoid using them.\n");
+                    oldstate = state;
+                }
+            }
         }
 
 

--- a/xboxdash/main.c
+++ b/xboxdash/main.c
@@ -20,6 +20,7 @@ int main(void)
     debugPrint("Please insert a disc...\n");
 
     ULONG state;
+    ULONG oldstate;
 
     while (1) {
         XVideoWaitForVBlank();


### PR DESCRIPTION
If it cant launch default.xbe, print out that their iso is probably packed wrong.